### PR TITLE
Fix autoload SygicAuth dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,12 +11,22 @@ let package = Package(
     products: [
         .library(
             name: "SygicMaps",
-            targets: ["SygicMaps"]),
+            targets: ["SygicMapsDependencyWrapper", "SygicMaps"]
+        )
     ],
     dependencies: [
         .package(url: "https://github.com/Sygic/SygicAuth-SPM", from: "1.3.2")
     ],
     targets: [
+        .target(
+            // This target helps to provide dependencies for binary target.
+            // Binary target cannot have dependencies itself, but target with source files can.
+            // That's why we add a stub target with a stub source file and declare dependencies for it.
+            name: "SygicMapsDependencyWrapper",
+            dependencies: [
+                .product(name: "SygicAuth", package: "SygicAuth-SPM")
+            ]
+        ),
         .binaryTarget(
             name: "SygicMaps",
             url: "https://public.repo.sygic.com/repository/maven-sygic-releases/com/sygic/sdk/maps-ios/25.5.4/maps-ios-25.5.4.zip",

--- a/Sources/SygicMapsDependencyWrapper/StubFile.swift
+++ b/Sources/SygicMapsDependencyWrapper/StubFile.swift
@@ -1,0 +1,5 @@
+// This stub source file helps to provide dependencies for binary target.
+// Binary target cannot have dependencies itself, but target with source files can.
+// That's why we add a stub target with a stub source file and declare dependencies for it.
+
+import Foundation


### PR DESCRIPTION
It was an issue that if you add only SygicMaps to a project, then SygicAuth dependency is not added automatically.